### PR TITLE
Fix Farsi date handling

### DIFF
--- a/app/common/domain/mappers/attributeFormatter.js
+++ b/app/common/domain/mappers/attributeFormatter.js
@@ -51,7 +51,7 @@ Bahmni.Common.Domain.AttributeFormatter = (function () {
             attr.hydratedObject = value.conceptUuid;
         } else if (attributeType.format == "org.openmrs.util.AttributableDate" || attributeType.format == "org.openmrs.customdatatype.datatype.DateDatatype") {
             var mnt = moment(value);
-            attr.value = mnt.format('YYYY-MM-DD');
+            attr.value = mnt.locale('en').format('YYYY-MM-DD');
         } else {
             attr.value = value.toString();
         }

--- a/app/common/util/dateTimeFormatter.js
+++ b/app/common/util/dateTimeFormatter.js
@@ -3,6 +3,6 @@
 Bahmni.Common.Util.DateTimeFormatter = {
 
     getDateWithoutTime: function (datetime) {
-        return datetime ? moment(datetime).format("YYYY-MM-DD") : null;
+        return datetime ? moment(datetime).locale('en').format("YYYY-MM-DD") : null;
     }
 };

--- a/app/common/util/dateUtil.js
+++ b/app/common/util/dateUtil.js
@@ -82,7 +82,7 @@ Bahmni.Common.Util.DateUtil = {
     },
 
     getDateWithoutTime: function (datetime) {
-        return datetime ? moment(datetime).format("YYYY-MM-DD") : null;
+        return datetime ? moment(datetime).locale('en').format("YYYY-MM-DD") : null;
     },
 
     getDateInMonthsAndYears: function (date, format) {
@@ -289,20 +289,20 @@ Bahmni.Common.Util.DateUtil = {
     },
 
     parseLongDateToServerFormat: function (longDate) {
-        return longDate ? moment(longDate).format("YYYY-MM-DDTHH:mm:ss.SSSZZ") : null;
+        return longDate ? moment(longDate).locale('en').format("YYYY-MM-DDTHH:mm:ss.SSSZZ") : null;
     },
 
     parseServerDateToDate: function (longDate) {
         return longDate ? moment(longDate, "YYYY-MM-DDTHH:mm:ss.SSSZZ").toDate() : null;
     },
     getDateTimeInSpecifiedFormat: function (date, format) {
-        return date ? moment(date).format(format) : null;
+        return date ? moment(date).locale('en').format(format) : null;
     },
     getISOString: function (date) {
         return date ? moment(date).toDate().toISOString() : null;
     },
     isBeforeTime: function (time, otherTime) {
-        return moment(time, clientTimeDisplayFormat).format('YYYY-MM-DD');
+        return moment(time, clientTimeDisplayFormat).locale('en').format('YYYY-MM-DD');
     },
     getWeekStartDate: function (date, startOfWeek) {
         var daysToBeSubtracted = this.subtractISOWeekDays(date, startOfWeek);

--- a/app/registration/mappers/createPatientRequestMapper.js
+++ b/app/registration/mappers/createPatientRequestMapper.js
@@ -68,7 +68,7 @@ Bahmni.Registration.CreatePatientRequestMapper = (function () {
         } else if (age !== undefined) {
             mnt = moment(this.currentDate).subtract('days', age.days).subtract('months', age.months).subtract('years', age.years);
         }
-        return mnt.format('YYYY-MM-DD');
+        return mnt.locale('en').format('YYYY-MM-DD');
     };
 
     return CreatePatientRequestMapper;

--- a/app/registration/mappers/updatePatientRequestMapper.js
+++ b/app/registration/mappers/updatePatientRequestMapper.js
@@ -94,7 +94,7 @@ Bahmni.Registration.UpdatePatientRequestMapper = (function () {
             attr.hydratedObject = value.conceptUuid;
         } else if (attributeType.format === "org.openmrs.util.AttributableDate") {
             var mnt = moment(value);
-            attr.value = mnt.format('YYYY-MM-DDTHH:mm:ss.SSSZZ');
+            attr.value = mnt.locale('en').format('YYYY-MM-DDTHH:mm:ss.SSSZZ');
         } else {
             attr.value = value.toString();
         }
@@ -107,7 +107,7 @@ Bahmni.Registration.UpdatePatientRequestMapper = (function () {
         } else if (age !== undefined) {
             mnt = moment(this.currentDate).subtract('days', age.days).subtract('months', age.months).subtract('years', age.years);
         }
-        return mnt.format('YYYY-MM-DDTHH:mm:ss.SSSZZ');
+        return mnt.locale('en').format('YYYY-MM-DDTHH:mm:ss.SSSZZ');
     };
 
     return UpdatePatientRequestMapper;


### PR DESCRIPTION
## Summary
- ensure dates sent to backend always use English digits

## Testing
- `yarn install` *(fails: Manifest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688150f7e2f88332bcdde9590e3029dd